### PR TITLE
チューナ空間名をMirakurunから取得するように変更

### DIFF
--- a/BonDriver_Mirakurun.h
+++ b/BonDriver_Mirakurun.h
@@ -1,5 +1,4 @@
-﻿#define _CRT_SECURE_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
+﻿#define _WINSOCK_DEPRECATED_NO_WARNINGS
 
 #include <tchar.h>
 #include <winsock2.h>
@@ -28,7 +27,12 @@ using namespace Net;
 #define TSDATASIZE	48128	// TSデータのサイズ 188 * 256
 
 static wchar_t g_IniFilePath[MAX_PATH] = { '\0' };
-const char *Space_Name[] = { "GR", "BS", "CS", "SKY" };
+
+// チューナ空間
+#define SPACE_NUM 8
+static char *g_pType[SPACE_NUM];
+static DWORD g_Max_Type;
+static DWORD g_Channel_Base[SPACE_NUM];
 
 #define MAX_HOST_LEN	256
 #define MAX_PORT_LEN	8
@@ -36,7 +40,7 @@ static char g_ServerHost[MAX_HOST_LEN];
 static char g_ServerPort[MAX_PORT_LEN];
 static int g_DecodeB25;
 static int g_Priority;
-picojson::value g_Channel_JSON[4];
+picojson::value g_Channel_JSON;
 static int g_MagicPacket_Enable;
 static char g_MagicPacket_TargetMAC[18];
 static char g_MagicPacket_TargetIP[16];
@@ -49,7 +53,10 @@ public:
 	CBonTuner();
 	virtual ~CBonTuner();
 
-// IBonDriver
+	// Initialize channel
+	void InitChannel(void);
+
+	// IBonDriver
 	const BOOL OpenTuner(void);
 	void CloseTuner(void);
 
@@ -134,13 +141,11 @@ protected:
 	float m_fBitRate;
 
 	void CalcBitRate();
-	void GetApiChannels(const char* space, picojson::value *json_array);
+	void GetApiChannels(picojson::value *json_array);
 	DWORD m_dwRecvBytes;
 	DWORD m_dwLastCalcTick;
 	ULONGLONG m_u64RecvBytes;
 	ULONGLONG m_u64LastCalcByte;
-
-
 };
 
 #endif // !defined(_BONTUNER_H_)

--- a/binzume/http.h
+++ b/binzume/http.h
@@ -16,7 +16,7 @@ std::string urlencode(const std::string &str)
 		if (c>='A' && c<='Z' || c>='a' && c<='z' || c>='0' && c<='9') {
 			s+=c;
 		} else {
-			sprintf(h,"%%%02x",c);
+			sprintf_s(h,"%%%02x",c);
 			s+=h;
 		}
 	}
@@ -36,7 +36,7 @@ std::string urldecode(const std::string &str)
 			h[1]=*++it;
 			h[2]=0;
 			int d;
-			sscanf(h,"%02x",&d);
+			sscanf_s(h,"%02x",&d);
 			s+=(char)d;
 		}
 	}
@@ -120,7 +120,7 @@ public:
 
 		if (method==POST || method==AUTO&&data.size()) {
 			char s[30];
-			sprintf(s,"Content-Length: %zd\r\n", data.size());
+			sprintf_s(s,"Content-Length: %zd\r\n", data.size());
 			soc.write(s);
 			soc.write("Content-Type: application/x-www-form-urlencoded\r\n");
 		}

--- a/binzume/socket.h
+++ b/binzume/socket.h
@@ -94,7 +94,7 @@ public:
 	Socket(const SOCKET &soc){m_socket = soc;}
 	Socket(const std::string &host,short port){
 		m_socket=socket(AF_INET, SOCK_STREAM, 0);
-		connect(host,port);
+		connect(host, port);
 	}
 	Socket(){m_socket=socket(AF_INET, SOCK_STREAM, 0);}
 
@@ -130,7 +130,7 @@ public:
 		return s;
 	}
 
-	bool connect(const std::string &host,short port){
+	bool connect(const std::string &host, short port){
 		if(m_socket==INVALID_SOCKET)
 			return false;
 
@@ -159,12 +159,12 @@ public:
 	}
 
 	int send(const void *buf,size_t len){
-		int ret=::send(m_socket,(const char*)buf,len,0);
+		int ret=::send(m_socket, (const char*)buf, (int)len, 0);
 		if (ret<1) close();
 		return ret;
 	}
 	int recv(void *buf,size_t len){
-		int ret=::recv(m_socket, (char*)buf, len, 0);
+		int ret=::recv(m_socket, (char*)buf, (int)len, 0);
 		if (ret<1) close();
 		return ret;
 	}


### PR DESCRIPTION
https://github.com/Chinachu/BonDriver_Mirakurun/issues/3
に記載の通り、
MirakurunからBonDriver_Mirakurunへの送信をチャンネルごとではなくサービスごとにするオプションの実装の前準備として、チューナ空間名をMirakurunから取得するように変更しています。
これにより、もしMirakurun側で追加や変更があった場合にも自動で対応できます。
また追加でWarningの抑制も行っています。