### PR TITLE
チャネル名をUTF-8文字列として扱う

### DIFF
--- a/BonDriver_Mirakurun.cpp
+++ b/BonDriver_Mirakurun.cpp
@@ -530,7 +530,7 @@ LPCTSTR CBonTuner::EnumChannelName(const DWORD dwSpace, const DWORD dwChannel)
 	std::string channel_name = channel_obj["name"].get<std::string>();
 
 	static TCHAR buf[128];
-	mbstowcs(buf, channel_name.c_str(), sizeof(buf));
+	::MultiByteToWideChar(CP_UTF8, 0, channel_name.c_str(), -1, buf, sizeof(buf));
 
 	return buf;
 }


### PR DESCRIPTION
Mirakurunより取得したチャネル名を含むJSON文字列はstd::string(UTF-8)であると思います。
TCHAR[]への変換時にUTF-8文字列として扱うことで日本語チャネル名が表示されるよう修正してみました。
JSON文字列全体をShift_JISに変換することも考えたのですが、必要な個所のみを変更するよう修正しています。