### PR TITLE
チューナ空間名をMirakurunから取得するように変更

### DIFF
--- a/BonDriver_Mirakurun.cpp
+++ b/BonDriver_Mirakurun.cpp
@@ -135,7 +135,7 @@ CBonTuner * CBonTuner::m_pThis = NULL;
 HINSTANCE CBonTuner::m_hModule = NULL;
 
 CBonTuner::CBonTuner()
-	: m_bTunerOpen(false)
+	: m_bTunerOpen(FALSE)
 	, m_hMutex(NULL)
 	, m_pIoReqBuff(NULL)
 	, m_pIoPushReq(NULL)
@@ -155,26 +155,32 @@ CBonTuner::CBonTuner()
 {
 	m_pThis = this;
 
+	// グローバル変数初期化
+	for (int i = 0; i < SPACE_NUM; i++) {
+		g_pType[i] = NULL;
+	}
+	
 	// クリティカルセクション初期化
 	::InitializeCriticalSection(&m_CriticalSection);
 
-	// Mirakurun APIよりchannel取得
-	int i = 0;
-	TCHAR buf[4];
-	for (int j = 0; j < 4; j++) {
-		GetApiChannels(Space_Name[j], &g_Channel_JSON[i]);
-		if (g_Channel_JSON[i].contains(0) == true) {
-			_stprintf(buf, TEXT("%hs"), Space_Name[j]);
-			_tcscpy(g_Space_Set[i], buf);
-			i++;
-		}
-	}
+	//Initialize channel
+	InitChannel();
 }
 
 CBonTuner::~CBonTuner()
 {
 	// 開かれてる場合は閉じる
 	CloseTuner();
+
+	// メモリ解放
+	for (int i = 0; i < SPACE_NUM; i++) {
+		if (g_pType[i]) {
+			free(g_pType[i]);
+		}
+		else {
+			break;
+		}
+	}
 
 	// クリティカルセクション削除
 	::DeleteCriticalSection(&m_CriticalSection);
@@ -187,8 +193,56 @@ CBonTuner::~CBonTuner()
 	m_pThis = NULL;
 }
 
+void CBonTuner::InitChannel()
+{
+	// Mirakurun APIよりchannel取得
+	GetApiChannels(&g_Channel_JSON);
+	if (g_Channel_JSON.is<picojson::null>()) {
+		return;
+	}
+	if (!g_Channel_JSON.contains(0)) {
+		return;
+	}
+
+	// チューナ空間取得
+	int i = 0;
+	int j = 0;
+	while (j < SPACE_NUM - 1) {
+		if (!g_Channel_JSON.contains(i)) {
+			break;
+		}
+		picojson::object& channel_obj = g_Channel_JSON.get(i).get<picojson::object>();
+		const char *type;
+		type = channel_obj["type"].get<std::string>().c_str();
+		if (!g_pType[0]) {
+			int len = (int)strlen(type) + 1;
+			g_pType[0] = (char *)malloc(len);
+			if (!g_pType[0]) {
+				break;
+			}
+			strcpy_s(g_pType[0], len, type);
+		}
+		else if (strcmp(g_pType[j], type)) {
+			int len = (int)strlen(type) + 1;
+			g_pType[++j] = (char *)malloc(len);
+			if (!g_pType[j]) {
+				j--;
+				break;
+			}
+			strcpy_s(g_pType[j], len, type);
+			g_Channel_Base[j] = i;
+		}
+		i++;
+	}
+	g_Max_Type = j;
+}
+
 const BOOL CBonTuner::OpenTuner()
 {
+	if (g_Channel_JSON.is<picojson::null>()) {
+		return FALSE;
+	}
+
 	if (!m_bTunerOpen) {
 		// Winsock初期化
 		WSADATA stWsa;
@@ -248,7 +302,7 @@ const BOOL CBonTuner::OpenTuner()
 							continue;
 						}
 
-						if (connect(m_sock, ai->ai_addr, ai->ai_addrlen) >= 0) {
+						if (connect(m_sock, ai->ai_addr, (int)ai->ai_addrlen) >= 0) {
 							// OK
 							break;
 						}
@@ -295,7 +349,7 @@ const BOOL CBonTuner::OpenTuner()
 			}
 		}
 
-		m_bTunerOpen = true;
+		m_bTunerOpen = TRUE;
 	}
 
 	//return SetChannel(0UL,0UL);
@@ -498,39 +552,37 @@ const BOOL CBonTuner::IsTunerOpening(void)
 
 LPCTSTR CBonTuner::EnumTuningSpace(const DWORD dwSpace)
 {
-	if (dwSpace > 3) {
-		return NULL;
-	}
-	if (g_Channel_JSON[dwSpace].is<picojson::array>() == false
-		|| g_Channel_JSON[dwSpace].get<picojson::array>().empty()
-	|| g_Channel_JSON[dwSpace].contains(0) == false) {
+	if (dwSpace > g_Max_Type) {
 		return NULL;
 	}
 
 	// 使用可能なチューニング空間を返す
-	return g_Space_Set[dwSpace];
+	static TCHAR buf[128];
+	::MultiByteToWideChar(CP_UTF8, 0, g_pType[dwSpace], -1, buf, sizeof(buf));
+	return buf;
 }
 
 LPCTSTR CBonTuner::EnumChannelName(const DWORD dwSpace, const DWORD dwChannel)
 {
-	picojson::value channel_json;
-
-	if (dwSpace > 3) {
+	if (dwSpace > g_Max_Type) {
 		return NULL;
 	}
-	channel_json = g_Channel_JSON[dwSpace];
+	if (dwSpace < g_Max_Type) {
+		if (dwChannel >= g_Channel_Base[dwSpace + 1] - g_Channel_Base[dwSpace]) {
+			return NULL;
+		}
+	}
 
-	if (channel_json.is<picojson::array>() == false
-		|| channel_json.get<picojson::array>().empty()
-		|| channel_json.contains(dwChannel) == false) {
+	DWORD Bon_Channel = dwChannel + g_Channel_Base[dwSpace];
+	if (!g_Channel_JSON.contains(Bon_Channel)) {
 		return NULL;
 	}
 
-	picojson::object& channel_obj = channel_json.get(dwChannel).get<picojson::object>();
-	std::string channel_name = channel_obj["name"].get<std::string>();
+	picojson::object& channel_obj = g_Channel_JSON.get(Bon_Channel).get<picojson::object>();
+	const char *channel_name = channel_obj["name"].get<std::string>().c_str();
 
 	static TCHAR buf[128];
-	::MultiByteToWideChar(CP_UTF8, 0, channel_name.c_str(), -1, buf, sizeof(buf));
+	::MultiByteToWideChar(CP_UTF8, 0, channel_name, -1, buf, sizeof(buf));
 
 	return buf;
 }
@@ -651,7 +703,7 @@ const BOOL CBonTuner::PushIoRequest(SOCKET sock)
 	// HTTP受信を要求スルニダ！
 	DWORD Flags = 0;
 	WSABUF wsaBuf;
-	wsaBuf.buf = (char*)m_pIoPushReq->RxdBuff;
+	wsaBuf.buf = (char *)m_pIoPushReq->RxdBuff;
 	wsaBuf.len = sizeof(m_pIoPushReq->RxdBuff);
 	if (SOCKET_ERROR == WSARecv(sock, &wsaBuf, 1, &m_pIoPushReq->dwRxdSize, &Flags, &m_pIoPushReq->OverLapped, NULL)) {
 		int sock_err = WSAGetLastError();
@@ -741,25 +793,21 @@ const BOOL CBonTuner::SetChannel(const BYTE bCh)
 // チャンネル設定
 const BOOL CBonTuner::SetChannel(const DWORD dwSpace, const DWORD dwChannel)
 {
-	if (dwSpace > 3) {
+	if (dwSpace > g_Max_Type) {
 		return NULL;
 	}
 
-	picojson::value channel_json;
-	channel_json = g_Channel_JSON[dwSpace];
-
-	if (channel_json.is<picojson::array>() == false
-		|| channel_json.get<picojson::array>().empty()
-		|| channel_json.contains(dwChannel) == false) {
+	DWORD Bon_Channel = dwChannel + g_Channel_Base[dwSpace];
+	if (!g_Channel_JSON.contains(Bon_Channel)) {
 		return NULL;
 	}
 
-	picojson::object& channel_obj = channel_json.get(dwChannel).get<picojson::object>();
-	std::string channel_name = channel_obj["name"].get<std::string>();
-	std::string channel = channel_obj["channel"].get<std::string>();
+	picojson::object& channel_obj = g_Channel_JSON.get(Bon_Channel).get<picojson::object>();
 
-	wchar_t wChannel[16];
-	mbstowcs(wChannel, channel.c_str(), sizeof(wChannel));
+	const char *type;
+	const char *channel;
+	type = channel_obj["type"].get<std::string>().c_str();
+	channel = channel_obj["channel"].get<std::string>().c_str();
 
 	// 一旦クローズ
 	CloseTuner();
@@ -777,20 +825,12 @@ const BOOL CBonTuner::SetChannel(const DWORD dwSpace, const DWORD dwChannel)
 	m_dwReadyReqNum = 0;
 
 	try{
+		char url[128];
 		char serverRequest[256];
 
-		// tmp
-		wchar_t tmpUrl[128];
-
-		WCHAR tmpServerRequest[256];
-
 		// URL生成
-		wsprintf(tmpUrl, L"/api/channels/%s/%s/stream?decode=%d", CBonTuner::EnumTuningSpace(dwSpace), wChannel, g_DecodeB25);
-
-		wsprintf(tmpServerRequest, L"GET %s HTTP/1.0\r\nX-Mirakurun-Priority: %d\r\n\r\n", tmpUrl, g_Priority);
-
-		size_t i;
-		wcstombs_s(&i, serverRequest, tmpServerRequest, sizeof(serverRequest));
+		sprintf_s(url, "/api/channels/%s/%s/stream?decode=%d", type, channel, g_DecodeB25);
+		sprintf_s(serverRequest, "GET %s HTTP/1.0\r\nX-Mirakurun-Priority: %d\r\n\r\n", url, g_Priority);
 
 		struct addrinfo hints;
 		struct addrinfo* res = NULL;
@@ -815,7 +855,7 @@ const BOOL CBonTuner::SetChannel(const DWORD dwSpace, const DWORD dwChannel)
 				continue;
 			}
 
-			if (connect(m_sock, ai->ai_addr, ai->ai_addrlen) >= 0) {
+			if (connect(m_sock, ai->ai_addr, (int)ai->ai_addrlen) >= 0) {
 				// OK
 				break;
 			}
@@ -915,11 +955,11 @@ void CBonTuner::CalcBitRate()
 	return;
 }
 
-void CBonTuner::GetApiChannels(const char* space, picojson::value* channel_json)
+void CBonTuner::GetApiChannels(picojson::value* channel_json)
 {
 	HttpClient client;
 	char url[512];
-	sprintf(url, "http://%s:%s/api/channels/%s", g_ServerHost, g_ServerPort, space);
+	sprintf_s(url, "http://%s:%s/api/channels", g_ServerHost, g_ServerPort);
 	HttpResponse response = client.get(url);
 
 	picojson::value v;
@@ -943,5 +983,4 @@ void CBonTuner::GetApiChannels(const char* space, picojson::value* channel_json)
 		}
 		*/
 	}
-
 }

--- a/BonDriver_Mirakurun.h
+++ b/BonDriver_Mirakurun.h
@@ -1,5 +1,4 @@
-﻿#define _CRT_SECURE_NO_WARNINGS
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
+﻿#define _WINSOCK_DEPRECATED_NO_WARNINGS
 
 #include <tchar.h>
 #include <winsock2.h>
@@ -28,7 +27,12 @@ using namespace Net;
 #define TSDATASIZE	48128	// TSデータのサイズ 188 * 256
 
 static wchar_t g_IniFilePath[MAX_PATH] = { '\0' };
-const char *Space_Name[] = { "GR", "BS", "CS", "SKY" };
+
+// チューナ空間
+#define SPACE_NUM 8
+static char *g_pType[SPACE_NUM];
+static DWORD g_Max_Type;
+static DWORD g_Channel_Base[SPACE_NUM];
 
 #define MAX_HOST_LEN	256
 #define MAX_PORT_LEN	8
@@ -36,7 +40,7 @@ static char g_ServerHost[MAX_HOST_LEN];
 static char g_ServerPort[MAX_PORT_LEN];
 static int g_DecodeB25;
 static int g_Priority;
-picojson::value g_Channel_JSON[4];
+picojson::value g_Channel_JSON;
 static int g_MagicPacket_Enable;
 static char g_MagicPacket_TargetMAC[18];
 static char g_MagicPacket_TargetIP[16];
@@ -49,7 +53,10 @@ public:
 	CBonTuner();
 	virtual ~CBonTuner();
 
-// IBonDriver
+	// Initialize channel
+	void InitChannel(void);
+
+	// IBonDriver
 	const BOOL OpenTuner(void);
 	void CloseTuner(void);
 
@@ -134,13 +141,11 @@ protected:
 	float m_fBitRate;
 
 	void CalcBitRate();
-	void GetApiChannels(const char* space, picojson::value *json_array);
+	void GetApiChannels(picojson::value *json_array);
 	DWORD m_dwRecvBytes;
 	DWORD m_dwLastCalcTick;
 	ULONGLONG m_u64RecvBytes;
 	ULONGLONG m_u64LastCalcByte;
-
-
 };
 
 #endif // !defined(_BONTUNER_H_)

--- a/binzume/http.h
+++ b/binzume/http.h
@@ -16,7 +16,7 @@ std::string urlencode(const std::string &str)
 		if (c>='A' && c<='Z' || c>='a' && c<='z' || c>='0' && c<='9') {
 			s+=c;
 		} else {
-			sprintf(h,"%%%02x",c);
+			sprintf_s(h,"%%%02x",c);
 			s+=h;
 		}
 	}
@@ -36,7 +36,7 @@ std::string urldecode(const std::string &str)
 			h[1]=*++it;
 			h[2]=0;
 			int d;
-			sscanf(h,"%02x",&d);
+			sscanf_s(h,"%02x",&d);
 			s+=(char)d;
 		}
 	}
@@ -120,7 +120,7 @@ public:
 
 		if (method==POST || method==AUTO&&data.size()) {
 			char s[30];
-			sprintf(s,"Content-Length: %zd\r\n", data.size());
+			sprintf_s(s,"Content-Length: %zd\r\n", data.size());
 			soc.write(s);
 			soc.write("Content-Type: application/x-www-form-urlencoded\r\n");
 		}

--- a/binzume/socket.h
+++ b/binzume/socket.h
@@ -94,7 +94,7 @@ public:
 	Socket(const SOCKET &soc){m_socket = soc;}
 	Socket(const std::string &host,short port){
 		m_socket=socket(AF_INET, SOCK_STREAM, 0);
-		connect(host,port);
+		connect(host, port);
 	}
 	Socket(){m_socket=socket(AF_INET, SOCK_STREAM, 0);}
 
@@ -130,7 +130,7 @@ public:
 		return s;
 	}
 
-	bool connect(const std::string &host,short port){
+	bool connect(const std::string &host, short port){
 		if(m_socket==INVALID_SOCKET)
 			return false;
 
@@ -159,12 +159,12 @@ public:
 	}
 
 	int send(const void *buf,size_t len){
-		int ret=::send(m_socket,(const char*)buf,len,0);
+		int ret=::send(m_socket, (const char*)buf, (int)len, 0);
 		if (ret<1) close();
 		return ret;
 	}
 	int recv(void *buf,size_t len){
-		int ret=::recv(m_socket, (char*)buf, len, 0);
+		int ret=::recv(m_socket, (char*)buf, (int)len, 0);
 		if (ret<1) close();
 		return ret;
 	}


### PR DESCRIPTION
https://github.com/Chinachu/BonDriver_Mirakurun/issues/3
に記載の通り、MirakurunからBonDriver_Mirakurunへの送信をチャンネルごとではなくサービスごとにするオプションの実装の前準備として、チューナ空間名をMirakurunから取得するように変更しています。

これにより、もしMirakurun側で追加や変更があった場合にも自動で対応できます。
また追加でWarningの抑制も行っています。
