### PR TITLE
サービスごとにスプリットされたTSデータを受信するオプションを追加

### DIFF
--- a/BonDriver_Mirakurun.h
+++ b/BonDriver_Mirakurun.h
@@ -1,11 +1,9 @@
 ﻿#define _WINSOCK_DEPRECATED_NO_WARNINGS
 
-#include <tchar.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <InitGuid.h>
 #include "IBonDriver2.h"
-#include "binzume\socket.h"
 #include "binzume\http.h"
 #include "picojson\picojson.h"
 using namespace std;
@@ -40,11 +38,11 @@ static char g_ServerHost[MAX_HOST_LEN];
 static char g_ServerPort[MAX_PORT_LEN];
 static int g_DecodeB25;
 static int g_Priority;
+static int g_Service_Split;
 picojson::value g_Channel_JSON;
 static int g_MagicPacket_Enable;
 static char g_MagicPacket_TargetMAC[18];
 static char g_MagicPacket_TargetIP[16];
-static TCHAR g_Space_Set[4][4];
 #define MAGICPACKET_WAIT_SECONDS 20
 
 class CBonTuner : public IBonDriver2
@@ -141,7 +139,7 @@ protected:
 	float m_fBitRate;
 
 	void CalcBitRate();
-	void GetApiChannels(picojson::value *json_array);
+	void GetApiChannels(picojson::value *json_array, int service_split);
 	DWORD m_dwRecvBytes;
 	DWORD m_dwLastCalcTick;
 	ULONGLONG m_u64RecvBytes;

--- a/BonDriver_Mirakurun.ini
+++ b/BonDriver_Mirakurun.ini
@@ -8,6 +8,9 @@ DECODE_B25=1
 ; Priority(0=Low Priority)
 PRIORITY=0
 
+; Service Split(1=enable)
+SERVICE_SPLIT=0
+
 ; MagicPacket(1=enable)
 MAGICPACKET_ENABLE=0
 MAGICPACKET_TARGETMAC="00:00:00:00:00:00"


### PR DESCRIPTION
ネットワーク帯域削減を目的として、Mirakurunの方であらかじめ1チャンネル1サービスにスプリットしてからBonDriver_Mirakurunで受信するためのコミットです。

下記のリンクで議論されています。
https://github.com/Chinachu/BonDriver_Mirakurun/issues/3
